### PR TITLE
Missed auth for github packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Authenticate with Github Packages
+          command: echo "//npm.pkg.github.com/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+      - run:
           name: Publish package
           command: npm publish
 


### PR DESCRIPTION
Oops, knew I missed something!  Included the github context in the pipeline, but forgot to put the token into the .npmrc file.  Other pipelines already have it included because of the persisting workspace.  Didn't think the workspace needed to be persisted though in this case because publishing doesn't require install/build/